### PR TITLE
Proposed fix for the behaviour of STP

### DIFF
--- a/src/vrEmu6502.c
+++ b/src/vrEmu6502.c
@@ -59,6 +59,7 @@ struct vrEmu6502_s
   uint16_t currentOpcodeAddr;
 
   bool wai;
+  bool stp;
 
   uint16_t pc;
 
@@ -293,6 +294,7 @@ VR_EMU_6502_DLLEXPORT void vrEmu6502Reset(VrEmu6502* vr6502)
     vr6502->pc = read16(vr6502, RESET_VEC);
     vr6502->step = 0;
     vr6502->wai = false;
+    vr6502->stp = false;
     vr6502->currentOpcode = 0;
     vr6502->tmpAddr = 0;
     vr6502->jam = 0;
@@ -326,6 +328,8 @@ static void beginInterrupt(VrEmu6502* vr6502, uint16_t addr)
 VR_EMU_6502_DLLEXPORT void __time_critical_func(vrEmu6502Tick)(VrEmu6502* vr6502)
 {
   if (vr6502->jam) return;
+
+  if (vr6502->stp) return;
 
   if (vr6502->step == 0)
   {
@@ -1789,8 +1793,9 @@ static void bbs7(VrEmu6502* vr6502, vrEmu6502AddrModeFn modeAddr) { bbs(vr6502, 
  */
 static void stp(VrEmu6502* vr6502, vrEmu6502AddrModeFn modeAddr)
 {
-  if (modeAddr)
-    --vr6502->pc;
+  (void)modeAddr;
+
+  vr6502->stp = true;
 }
 
 /*

--- a/src/vrEmu6502.c
+++ b/src/vrEmu6502.c
@@ -73,7 +73,6 @@ struct vrEmu6502_s
   uint16_t zpBase;
   uint16_t spBase;
   uint16_t tmpAddr;
-  bool jam;
 
   const vrEmu6502Opcode* opcodes;
   const char* mnemonicNames[256];
@@ -297,7 +296,6 @@ VR_EMU_6502_DLLEXPORT void vrEmu6502Reset(VrEmu6502* vr6502)
     vr6502->stp = false;
     vr6502->currentOpcode = 0;
     vr6502->tmpAddr = 0;
-    vr6502->jam = 0;
 
     /* 65c02 clears D and sets I on reset */
     if (is65c02(vr6502))
@@ -327,8 +325,6 @@ static void beginInterrupt(VrEmu6502* vr6502, uint16_t addr)
  */
 VR_EMU_6502_DLLEXPORT void __time_critical_func(vrEmu6502Tick)(VrEmu6502* vr6502)
 {
-  if (vr6502->jam) return;
-
   if (vr6502->stp) return;
 
   if (vr6502->step == 0)
@@ -2011,7 +2007,7 @@ static void jam(VrEmu6502* vr6502, vrEmu6502AddrModeFn modeAddr)
   (void)modeAddr;
 
   vr6502->readFn(imm(vr6502), false);
-  vr6502->jam = 1;
+  vr6502->stp = true;
 }
 
 /* ------------------------------------------------------------------


### PR DESCRIPTION
I have 2 setups, one using a real WDC65C02 connected to a Teensy 4.1 and another using vrEmu6502 on a Pico.
The behaviour of STP in the emu did not correspond to reality, so here is a proposed fix that seems to work well for me.
I am not confident in the new code of the STP-function, it might need some more code, but the patched behaviour of STP reflects what I observe on the WDC65C02 version.